### PR TITLE
Bug report form needs to be cleared out.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The web component takes certain inputs and returns an event on success which can
 
 ## Features
 The following are features which are easily extendible:
-* User can select from a preset options pased on page type.
+* User can select from a preset options based on page type.
 * User can share a screenshot.
 * User can write a detailed report.
 
@@ -40,14 +40,15 @@ For example:
 
 ## Editable attributes
 **1. title**  
-This will be the title that will be in the event on submitting the buug report.  
+This will be the title in the event on submitting the bug report.  
 **2. page-type**   
-This is a list of hardcoded questions based on the following [types](https://github.com/virtual-labs/svc-bug-report/blob/wc/questions.json).  
+This is a list of hardcoded questions based on the following [types](hhttps://github.com/virtual-labs/svc-bug-report/blob/main/questions.json).  
+
 Depending on the type given, the Multiple Choice options will be rendered.  
 **3. context-info**   
-This is data which will be passed as it is, this is left for developer to deal with. One possible use case would be to pass custom data for google analytics.  
+This data will be passed as it is, this is left for developer to deal with. One possible use case would be to pass custom data for google analytics.  
 **4. checkbox-json**
-This would consist of additonal questions which you want to ask, the format for the same is as follows [here](https://github.com/virtual-labs/ph3-lab-mgmt/blob/plugin/bug-report-wc/assets_plugins/json/bug-report-questions.js)
+This would consist of additional questions which you want to ask, the format for the same is as follows [here](https://github.com/virtual-labs/ph3-lab-mgmt/blob/master/assets_plugins/json/bug-report-questions.js)
 **5. button_style**  
 You need to add styling to this attribute if you would like to add css to bug report button.  
 **6. position**  
@@ -68,8 +69,8 @@ Similar to button_style, but in the case where you want button to follow styling
 
 ## To Move to Production
 1. For moving the bug report from testing to deployment please remove the if condition from the following two files
-   1. https://github.com/virtual-labs/ph3-lab-mgmt/blob/master/templates/partials/bug-report-mobile.handlebars 
-   2. https://github.com/virtual-labs/ph3-lab-mgmt/blob/master/templates/partials/header.handlebars#L16
+   1. https://github.com/virtual-labs/ph3-lab-mgmt/blob/master/exp_build/templates/partials/bug-report-mobile.handlebars 
+   2. https://github.com/virtual-labs/ph3-lab-mgmt/blob/master/exp_build/templates/partials/header.handlebars#L16
 2. This will build bug report in all stages of deployment.
 
 ## TODO

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SVC Bug Report WebComponent for Virtual Labs
 This repo contains the code for bug report web component for virtual labs, which can be used in any HTML webpage.  
-The web component takes certain inputs and returns an event on success which can be handled however the developer would like.  
+The web component takes certain inputs and returns an event on success, which can be handled however the developer would like.  
 
 ## Features
 The following are features which are easily extendible:
@@ -46,11 +46,11 @@ This is a list of hardcoded questions based on the following [types](hhttps://gi
 
 Depending on the type given, the Multiple Choice options will be rendered.  
 **3. context-info**   
-This data will be passed as it is, this is left for developer to deal with. One possible use case would be to pass custom data for google analytics.  
+This data will be passed as it is, this is left for the developer to deal with. One possible use case would be to pass custom data for google analytics.  
 **4. checkbox-json**
-This would consist of additional questions which you want to ask, the format for the same is as follows [here](https://github.com/virtual-labs/ph3-lab-mgmt/blob/master/assets_plugins/json/bug-report-questions.js)
+This would consist of additional questions which you want to ask. The format for the same is as follows [here](https://github.com/virtual-labs/ph3-lab-mgmt/blob/master/assets_plugins/json/bug-report-questions.js)
 **5. button_style**  
-You need to add styling to this attribute if you would like to add css to bug report button.  
+This would need styling if you would like to add css to bug report button. 
 **6. position**  
 This can be either of:  
   * top
@@ -59,16 +59,16 @@ This can be either of:
   * right
   * top left
   * bottom right etc
-If you want to add your own positioning, set position to ```override``` and add position css to style normally. (this is shown in example above)  
+If you want to add your own positioning, set position to ```override``` and add position css to style normally. (This is shown in example above)  
 
 **7. custom_button_class**  
-Similar to button_style, but in the case where you want button to follow styling from a class, pass the class name here.  
+Similar to button_style, but in the case, if you want the button to follow styling from a class, pass the class name here.  
 
 ## Events
-1. ```bugreport_success``` event is raised on suceessful submission, this can be handled however developer wants.  
+1. ```bugreport_success``` event is raised on suceessful submission, this can be handled however developer wants.  Currently the success message appear at the center of the page.
 
 ## To Move to Production
-1. For moving the bug report from testing to deployment please remove the if condition from the following two files
+1. For moving the bug report from testing to deployment, please remove the if condition from the following two files
    1. https://github.com/virtual-labs/ph3-lab-mgmt/blob/master/exp_build/templates/partials/bug-report-mobile.handlebars 
    2. https://github.com/virtual-labs/ph3-lab-mgmt/blob/master/exp_build/templates/partials/header.handlebars#L16
 2. This will build bug report in all stages of deployment.

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # SVC Bug Report WebComponent for Virtual Labs
-This repo contains the code for bug report web component for virtual labs, which can be used in any HTML webpage.  
+This repo contains the code for the bug report web component for virtual labs, which can be used in any HTML webpage.  
 The web component takes certain inputs and returns an event on success, which can be handled however the developer would like.  
 
 ## Features
-The following are features which are easily extendible:
-* User can select from a preset options based on page type.
+The following are features that are easily extendible:
+* User can select from preset options based on the page type.
 * User can share a screenshot.
 * User can write a detailed report.
 
-We mandate at least two of the three to be done, for precision.
+We mandate at least two of the three to be done for precision.
 
 ## How To Use
 1. In the root html file, the js script needs to be imported as a module.
-2. Then wherever you want to use the bug report component to be placed, use it like any other html component,```<bug-report></bugreport>```
+2. Then, wherever you want to use the bug report component to be placed, use it like any other html component,```<bug-report></bugreport>```
 For example:
 ```
 <html>
@@ -40,38 +40,30 @@ For example:
 
 ## Editable attributes
 **1. title**  
-This will be the title in the event on submitting the bug report.  
+This attribute specifies the title displayed when a bug report is submitted.
 **2. page-type**   
-This is a list of hardcoded questions based on the following [types](hhttps://github.com/virtual-labs/svc-bug-report/blob/main/questions.json).  
-
-Depending on the type given, the Multiple Choice options will be rendered.  
+This attribute defines a list of predefined question sets based on specific types, as referenced [here](https://github.com/virtual-labs/svc-bug-report/blob/main/questions.json). The selected type determines the Multiple Choice options that will be displayed.  
 **3. context-info**   
-This data will be passed as it is, this is left for the developer to deal with. One possible use case would be to pass custom data for google analytics.  
+This attribute allows for the inclusion of additional context-specific data. The data will be passed unchanged, giving developers flexibility in how it's utilized. A common use case is to pass custom data for Google Analytics or other tracking tools.
 **4. checkbox-json**
-This would consist of additional questions which you want to ask. The format for the same is as follows [here](https://github.com/virtual-labs/ph3-lab-mgmt/blob/master/assets_plugins/json/bug-report-questions.js)
+This attribute contains additional questions you wish to ask the user. These questions should follow the format outlined [here](https://github.com/virtual-labs/ph3-lab-mgmt/blob/master/assets_plugins/json/bug-report-questions.js)
 **5. button_style**  
-This would need styling if you would like to add css to bug report button. 
+This attribute specifies the styling for the bug report button. You can define custom CSS properties here to customize the appearance of the button.
 **6. position**  
-This can be either of:  
-  * top
-  * left
-  * bottom
-  * right
-  * top left
-  * bottom right etc
-If you want to add your own positioning, set position to ```override``` and add position css to style normally. (This is shown in example above)  
-
+This attribute defines the position of the bug report button. Available options include 'top,' 'left,' 'bottom,' 'right,' 'top left,' 'bottom right,' and others. To apply custom positioning, set the attribute to 'override' and apply CSS styling directly.
 **7. custom_button_class**  
-Similar to button_style, but in the case, if you want the button to follow styling from a class, pass the class name here.  
+Similar to 'button_style', this attribute allows you to specify a class name for the button. The button will inherit all styles defined in the class.
 
 ## Events
-1. ```bugreport_success``` event is raised on suceessful submission, this can be handled however developer wants.  Currently the success message appear at the center of the page.
+1. The ```bugreport_success``` event is triggered upon successful submission of a bug report. Developers can handle this event as needed. By default, a success message will be displayed at the center of the page.
+2. The ```bugreport_failure``` event is triggered upon failed submission of a bug report. Developers can try to re-submit. By default, a failure message will be displayed at the center of the page.
 
 ## To Move to Production
-1. For moving the bug report from testing to deployment, please remove the if condition from the following two files
-   1. https://github.com/virtual-labs/ph3-lab-mgmt/blob/master/exp_build/templates/partials/bug-report-mobile.handlebars 
-   2. https://github.com/virtual-labs/ph3-lab-mgmt/blob/master/exp_build/templates/partials/header.handlebars#L16
-2. This will build bug report in all stages of deployment.
+1. To move the bug report from testing to production, follow these steps:
+  1. Remove the if condition from the following files:
+   1. [bug-report-mobile.handlebars](https://github.com/virtual-labs/ph3-lab-mgmt/blob/master/exp_build/templates/partials/bug-report-mobile.handlebars)
+   2. [header.handlebars](https://github.com/virtual-labs/ph3-lab-mgmt/blob/master/exp_build/templates/partials/header.handlebars#L16)
+2. This will ensure the bug report feature is deployed across all stages of the environment.
 
 ## TODO
 Host the wc branch on github pages

--- a/client/src/bug-report.js
+++ b/client/src/bug-report.js
@@ -64,17 +64,24 @@ function getDateTime() {
  * @returns {Promise}
  */
 async function postData(url = "", data = {}) {
-  const res = await fetch(url, {
-    method: "POST",
-    cache: "no-cache",
-    headers: {
-      "X-Api-Key": "dKLwHjAj1759ytPPXu3H65ZFp9aoZFor4Xv4Fc4v",
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(data), // body data type must match "Content-Type" header
-  });
-  return res;
-  // return response.json(); // parses JSON response into native JavaScript objects
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      cache: "no-cache",
+      headers: {
+        "X-Api-Key": "dKLwHjAj1759ytPPXu3H65ZFp9aoZFor4Xv4Fc4v",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(data), // body data type must match "Content-Type" header
+    });
+    if (!res.ok) {
+      throw new Error(`HTTP error! status: ${res.status}`);
+    }
+    return res;
+    // return response.json(); // parses JSON response into native JavaScript objects
+  }catch (error) {    
+    throw new Error(`Error: ${error.message}`);  
+  }
 }
 
 /**
@@ -441,9 +448,24 @@ customElements.define(
                 }
           } catch (error) {
             // Handle submission error
-            console.error('Error submitting form:', error);
+            console.error('Error while submitting the bug :', error);            
+            // Dispatch the vl-bug-report event with the error details
+            const errorEvent = new CustomEvent('vl-bug-report', {
+              detail: { 
+                title: bug_info["title"],
+                status: error.status || 'unknown',
+                message: 'Bug report failed',
+                error: error 
+              },
+              bubbles: true,
+              cancelable: true,
+              composed: true
+            });
+            //console.log('errorEvent);             
+            shadowRoot.dispatchEvent(errorEvent);
           } finally {
             // Reset the form irrespective of the outcome
+            //console.log('Resetting the form');
             resetForm(shadowRoot);
           }
         }

--- a/client/src/bug-report.js
+++ b/client/src/bug-report.js
@@ -134,6 +134,23 @@ const submit_bug_report = async (
   return response;
 };
 
+// Function to reset the form fields
+function resetForm(shadowRoot) {
+  shadowRoot.getElementById("tf_description").value = '';
+  shadowRoot.getElementById("tf_email").value = '';
+  shadowRoot.getElementById("ss-checkbox").checked = false;
+
+  const image_container = shadowRoot.getElementById("image-container");
+  while (image_container.firstChild) {
+    image_container.removeChild(image_container.firstChild);
+  }
+
+  const checkboxes = shadowRoot.querySelectorAll('input[type="checkbox"]');
+  checkboxes.forEach(checkbox => {
+    checkbox.checked = false;
+  });
+}
+
 /**
  * Creating a bug report element
  */
@@ -310,6 +327,16 @@ customElements.define(
           modal.style.paddingRight = "17px";
           modal.className = "modal fade show";
         });
+
+      shadowRoot
+        .getElementById("bug-report-button")
+        .addEventListener("click", async function (e) {
+          resetForm(shadowRoot); // Reset the form fields
+          modal.style.display = "block";
+          modal.style.paddingRight = "17px";
+          modal.className = "modal fade show";
+        });
+
       shadowRoot
         .getElementById("close-button")
         .addEventListener("click", function () {
@@ -417,19 +444,7 @@ customElements.define(
             console.error('Error submitting form:', error);
           } finally {
             // Reset the form irrespective of the outcome
-            shadowRoot.getElementById("tf_description").value = '';
-            shadowRoot.getElementById("tf_email").value = '';
-            shadowRoot.getElementById("ss-checkbox").checked = false;          
-
-            const image_container = shadowRoot.getElementById("image-container");
-            const img = image_container.getElementsByTagName("img")[0];
-            while (image_container.firstChild) {
-              image_container.removeChild(image_container.firstChild);
-            }
-            const checkboxes = shadowRoot.querySelectorAll('input[type="checkbox"]');
-            checkboxes.forEach(checkbox => {
-              checkbox.checked = false;
-            });          
+            resetForm(shadowRoot);
           }
         }
       });

--- a/client/src/bug-report.js
+++ b/client/src/bug-report.js
@@ -227,7 +227,7 @@ customElements.define(
       switch (name) {
         case "checkbox-json":
           // console.log(`Value changed from ${oldValue} to ${newValue}`);
-          this.addCheckboxes();
+          this.addCheckboxes(); //add checkboxes to the form when the checkbox-json attribute changes
           break;
         case "context-info":
           // console.log(`Value changed from ${oldValue} to ${newValue}`);
@@ -316,7 +316,7 @@ customElements.define(
           this.custom_button_class;
       }
 
-      this.addCheckboxes();
+      this.addCheckboxes(); // Add checkboxes to the form at the start
 
       shadowRoot
         .getElementById("bug-report-button")
@@ -455,7 +455,7 @@ customElements.define(
                 title: bug_info["title"],
                 status: error.status || 'unknown',
                 message: 'Bug report failed',
-                error: error 
+                error: error
               },
               bubbles: true,
               cancelable: true,


### PR DESCRIPTION
Problem - After a certain bug is submitted, for the next bug filing, the form would come pre-filled with the previously filed bug details. We needed to clear out the form after submitting the bug.

Solution - We need to reset the form, after submitting the form. But only resetting the details of form after submission did not seem to work. So, I have added the reset function and it is called twice - at the beginning of the click event listener for the bug-report-button and also after the submission of the bug is completed.