### PR TITLE
clear out issues list at the closing.

### DIFF
--- a/client/src/bug-report.js
+++ b/client/src/bug-report.js
@@ -346,19 +346,21 @@ customElements.define(
 
       shadowRoot
         .getElementById("close-button")
-        .addEventListener("click", function () {
+        .addEventListener("click", () => {
+          console.log("Close button clicked");
+          this.bug_info.issues = [];
           modal.style.display = "none";
           modal.className = "modal fade";
         });
       shadowRoot
         .getElementById("close_x_button")
-        .addEventListener("click", function () {
+        .addEventListener("click", () => {
           modal.style.display = "none";
           modal.className = "modal fade";
         });
       shadowRoot
         .querySelector(".modal")
-        .addEventListener("click", function (e) {
+        .addEventListener("click", (e) => {
           if (e.target !== modal) return;
           modal.style.display = "none";
           modal.className = "modal fade";


### PR DESCRIPTION
Fix is for the issue - https://github.com/virtual-labs/svc-bug-report/issues/15

Replaced the regular functions with arrow functions for the event listeners. This ensures that 'this' inside the arrow function refers to the instance of the class. That means we can access `this.bug_info` correctly.  Now, the bug_info .issues list is cleared out wehenver close button or sign is clicked.